### PR TITLE
Avoid printing Incomplete's toString

### DIFF
--- a/adapter/src/main/scala-2.10/Adapter.scala
+++ b/adapter/src/main/scala-2.10/Adapter.scala
@@ -4,6 +4,7 @@ import org.apache.ivy.core.module.descriptor.ModuleDescriptor
 package sbt.dbuild.hack {
 object DbuildHack {
   val Load = sbt.Load
+  val ExceptionCategory = sbt.ExceptionCategory
 }
 }
 

--- a/adapter/src/main/scala-2.12/Adapter.scala
+++ b/adapter/src/main/scala-2.12/Adapter.scala
@@ -8,6 +8,7 @@ object DbuildHack {
    sbt.librarymanagement.CrossVersion.applyCross
   val defaultID: (java.io.File,String) => String =
    sbt.internal.BuildDef.defaultID
+  val ExceptionCategory = sbt.ExceptionCategory
 }
 }
 package com.typesafe.dbuild.adapter {

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ lazy val indexmeta = (
 lazy val logging = (
   SubProj("logging")
   dependsOn(adapter,graph)
-  dependsOnSbtProvided(sbtLogging, sbtIo, dbuildLaunchInt)
+  dependsOnSbtProvided(sbtLogging, sbtIo, sbtCommand, dbuildLaunchInt)
 )
 
 lazy val actorLogging = (

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/StateHelpers.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/StateHelpers.scala
@@ -1,40 +1,39 @@
 package com.typesafe.dbuild.plugin
 
 import sbt._
-import com.typesafe.dbuild.model
+import sbt.dbuild.hack.DbuildHack.ExceptionCategory
 import org.apache.commons.io.FileUtils.writeStringToFile
 
 object StateHelpers {
   def getProjectRefs(extracted: Extracted): Seq[ProjectRef] =
     extracted.structure.allProjectRefs
 
-  private def saveMsg(e: Throwable, lastMsgFile: File) = {
+  private def saveMsg(e: Throwable, lastMsgFile: File): Nothing = {
     val msg = e match {
-      case x:sbt.Incomplete =>
-        x.message match {
-          case Some(s) => s
-          case None => x.directCause match {
-            case Some(i) => Option(i.getMessage) getOrElse ""
-            case None => ""
-          }
-        }
+      case x: Incomplete =>
+        x.message orElse (x.directCause flatMap (t => Option(t.getMessage))) getOrElse ""
       case x => x.getMessage
     }
     writeStringToFile(lastMsgFile, msg, "UTF-8")
-    e.printStackTrace()
+    import ExceptionCategory.{ AlreadyHandled, MessageOnly, Full }
+    ExceptionCategory(e) match {
+      case AlreadyHandled => ()
+      case m: MessageOnly => System.err.println(m.message)
+      case _: Full        => e.printStackTrace()
+    }
     throw e
   }
   
   def saveLastMsg(lastMsgFile: File, f: (State, Seq[String]) => State)(state: State, args: Seq[String]): State = try {
     f(state, args)
   } catch {
-    case e:Throwable => saveMsg(e, lastMsgFile)
+    case e: Throwable => saveMsg(e, lastMsgFile)
   }
   
   def saveLastMsg(lastMsgFile: File, f: State => State)(state: State): State = try {
     f(state)
   } catch {
-    case e:Throwable => saveMsg(e, lastMsgFile)
+    case e: Throwable => saveMsg(e, lastMsgFile)
   }
 
 }

--- a/project/src/main/scala-2.10/Dependencies.scala
+++ b/project/src/main/scala-2.10/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies extends CommonDependencies {
   def sbtIo(v:String)        = "org.scala-sbt" % "io" % v
   def sbtIvy(v:String)       = "org.scala-sbt" % "ivy" % v
   def sbtLogging(v:String)   = "org.scala-sbt" % "logging" % v
+  def sbtCommand(v:String)   = "org.scala-sbt" % "command" % v
   def sbtSbt(v:String)       = "org.scala-sbt" % "sbt" % v
 
   val zincIf212              = None:Option[String=>ModuleID]

--- a/project/src/main/scala-2.12/Dependencies.scala
+++ b/project/src/main/scala-2.12/Dependencies.scala
@@ -12,6 +12,7 @@ object Dependencies extends CommonDependencies {
   def sbtIo(v:String)             = "org.scala-sbt" %% "io" % "1.0.0"
   def sbtIvy(v:String)            = "org.scala-sbt" %% "librarymanagement-ivy" % "1.0.0"
   def sbtLogging(v:String)        = "org.scala-sbt" %% "util-logging" % "1.0.0"
+  def sbtCommand(v:String)        = "org.scala-sbt" %% "command" % "1.0.0"
   def sbtSbt(v:String)            = "org.scala-sbt" % "sbt" % v
 
   val zincIf212                   = Some({ v:String => "org.scala-sbt" %% "zinc" % "1.0.0" })


### PR DESCRIPTION
Incomplete (optionally) holds a reference to the task key (in my
experience values of type ScopedKey) that did not complete, as well as
the multiple possible causes, which are also Incomplete instances and
therefore the whole thing is recursive. Add to that the toString of
ScopedKey is extremely verbose, and you end up in a situation where
failures generate so much log that Jenkins gives up with a "Max Log Size
reached. Aborting" message, and attempting to download the full log file
from Jenkins (which turns out to be 106 MiB) even crashes your Google
Chrome tab..

sbt's Incompletes aren't meant to be printed, as indicated them by
mixing in UnprintableException, which is handled by ExceptionCategory.
So let's use that when attempts are made to print the stacktrace so the
dbuild experience is more pleasant.

Fixes #194, or at least I think it should and hope it does - I'm not
setup to test this.