### PR TITLE
Consider 'skip in publish' while extracting and building artifacts

### DIFF
--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -799,8 +799,9 @@ object DBuildRunner {
   /** Settings you can add your build to print dependencies. */
   def buildSettings: Seq[Setting[_]] = Seq(Keys.commands += buildIt)
 
-  def extractArtifactLocations(org: String, version: String, artifacts: Map[Artifact, File],
-    cross: Adapter.CrossVersion, sv: String, sbv: String, sbtbv: String, isSbtPlugin: Boolean): Seq[model.ArtifactLocation] = {
+  def extractArtifactLocations(org: String, version: String, artifacts: Map[Artifact, File], skipInPublish: Boolean,
+    cross: Adapter.CrossVersion, sv: String, sbv: String, sbtbv: String, isSbtPlugin: Boolean): Seq[model.ArtifactLocation] =
+  if (skipInPublish) Seq.empty else {
     val crossSuffix = applyCross("", CrossVersion(cross, sv, sbv))
     for {
       (artifact, file) <- artifacts.toSeq
@@ -830,8 +831,9 @@ object DBuildRunner {
   }
 
   def projectSettings: Seq[Setting[_]] = Seq(
-    extractArtifacts := extractArtifactLocations(Keys.organization.value, Keys.version.value, (Keys.packagedArtifacts in Compile).value,
-      Keys.crossVersion.value, Keys.scalaVersion.value, Keys.scalaBinaryVersion.value, Keys.sbtBinaryVersion.value, Keys.sbtPlugin.value),
+    extractArtifacts := extractArtifactLocations(Keys.organization.value, Keys.version.value,
+      (Keys.packagedArtifacts in Compile).value, (Keys.skip in Keys.publish).value, Keys.crossVersion.value,
+      Keys.scalaVersion.value, Keys.scalaBinaryVersion.value, Keys.sbtBinaryVersion.value, Keys.sbtPlugin.value),
     moduleInfo := generateModuleInfo(Keys.organization.value, Keys.moduleName.value, Keys.version.value, Keys.scalaVersion.value,
       Keys.scalaBinaryVersion.value, Keys.sbtVersion.value, Keys.sbtBinaryVersion.value, Keys.sbtPlugin.value, Keys.crossVersion.value)
   )

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DependencyAnalysis.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DependencyAnalysis.scala
@@ -36,7 +36,8 @@ object DependencyAnalysis {
         model.ProjectRef("scala-compiler", "org.scala-lang", "jar", None)
 
       // Project Artifacts
-      val artifacts = for {
+      val skipPublish = extracted.runTask(Keys.skip in (ref, Keys.publish), state)._2
+      val artifacts = if (skipPublish) Seq[model.ProjectRef]() else for {
         a <- extracted get (Keys.artifacts in ref)
       } yield model.ProjectRef(fixName(a.name), organization, a.extension, a.classifier)
 


### PR DESCRIPTION
The `skip in publish` flag must be considered when getting the
list of dependencies artifacts, during extraction and
building. If skip in publish is set, the list of dependencies
is kept, but we consider that no artifact is produced.

This is only partly correct, since the generated artifacts would still be visible by
the inter-project resolver, even if they are not published. On the other hand, builds
currently performed by dbuild, prior to this patch, would also fail to publish
artifacts that can be seen by other subprojects since "publish" is hijacked to collect
artifacts.

Fixes #205