### PR TITLE
degrade to warning missing excluded projects

### DIFF
--- a/support/src/main/scala/com/typesafe/dbuild/support/scala/ScalaBuildSystem.scala
+++ b/support/src/main/scala/com/typesafe/dbuild/support/scala/ScalaBuildSystem.scala
@@ -338,7 +338,7 @@ object ScalaBuildSystem extends BuildSystemCore {
     val readMetaInfo = readMeta.projInfo.headOption getOrElse sys.error("Internal error: readMeta had no projInfo")
     val metaInfo = if (exclude.nonEmpty) {
       val notFound = exclude.diff(allSubProjects)
-      if (notFound.nonEmpty) sys.error(notFound.mkString("These subprojects were not found in scala: ", ", ", ""))
+      if (notFound.nonEmpty) log.warn(notFound.mkString("These subprojects were not found in scala: ", ", ", ""))
       val subProjects = allSubProjects.diff(exclude)
       // Note: Here subProjects contains a list of subprojects in the order
       // in which the names appear in the list of meta "projects". This does not


### PR DESCRIPTION
The rationale behind this is that any evolution to a library that involves "more modularization" will fail and will require extra effort to be maintained.

In my experience often happen that a library get splitted in several modules while growing.
Currently Dbuild does not support this kind of pattern in a back-compatible manner, having this `error` degraded to a simple `warning` will facilitate this use-case and has AFAICS no huge drawbacks.

cc. @eed3si9n @cunei #211 