### PR TITLE
 Allow patterns in "projects" and "exclude" for sbt projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,6 +188,7 @@ lazy val plugin = (
   SubProj("plugin") 
   settings(sbtPlugin := true)
   dependsOn(adapter, support, metadata)
+  dependsOnRemote(oro)
   dependsOnSbtProvided(sbtIo)
 )
 

--- a/docs/src/sphinx/dbuild.rst
+++ b/docs/src/sphinx/dbuild.rst
@@ -367,18 +367,30 @@ projects
   of the specified subprojects, dbuild will also add recursively all of the
   subprojects that are in the same project and that are required dependencies
   of the specified ones; if the subproject is an sbt aggregate, its components
-  will also be added. If the "projects" clause is not present, all of the
+  will also be added. If the "projects" clause is absent, all of the
   subprojects will be included.
 
-  If the project uses sbt's default projects, the actual subproject name may
-  vary over time and take forms like "default-e3c4f7". In order to refer to
-  sbt's default subproject, you can use the predefined name `"default-sbt-project"`.
+  In place of a fixed name, each element of the list can also be a pattern. In that
+  case, all of the sbt subprojects that match the given pattern will be be selected.
+  Patterns may also be used to match subprojects that may or may not be
+  present. The syntax is the shell-stype glob format, for instance
+  `some?patte[rR]n*`. You can find
+  `here <https://svn.apache.org/repos/asf/jakarta/oro/tags/oro-2.0.9-dev-1/docs/api/org/apache/oro/text/GlobCompiler.html>`_
+  the full description of the supported syntax.
+
+  Note: if the sbt build file of your project does not specify any subproject name,
+  sbt will generate a default subproject with a default name, which is not known in advance.
+  That name may vary over time and may take arbitrary forms like "default-e3c4f7". If you need to
+  refer to that subproject, you can use the predefined name `"default-sbt-project"`, and
+  dbuild will automatically resolve it to sbt's default subproject.
 
 exclude
   Sometimes it may be useful to split a single project into two or more parts.
   This clause can be used to exclude explicitly one or more of the subprojects, which
   can then be compiled in a different project within the same configuration file,
-  using a different project name but using the same uri.
+  using a different project name but using the same uri. Patterns may also be used
+  to exclude a group of subprojects, which may or may not be present, with the same
+  syntax as above.
 
 run-tests
   Boolean value: if set to false, the project will be built but no tests will be run.

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -31,6 +31,7 @@ import com.typesafe.dbuild.support.sbt.{ RewireInput, GenerateArtifactsInput }
 import com.typesafe.dbuild.support.SbtUtil.{ pluginAttrs, fixAttrs }
 import com.typesafe.dbuild.model.SbtPluginAttrs
 import scala.reflect.ClassManifest
+import org.apache.oro.text.regex
 
 object DBuildRunner {
 
@@ -56,7 +57,7 @@ object DBuildRunner {
     val Some(baseDirectory) = Keys.baseDirectory in ThisBuild get structure.data
     val refs = getProjectRefs(extracted)
     // I need a subset of refs, a sequence in the order specified by "project"
-    val newRefs = getSortedProjects(projects, refs, baseDirectory)
+    val newRefs = getSortedProjects(projects, refs, baseDirectory, acceptPatterns = false)
     newRefs.foldLeft[(State, Q)](state -> init) {
       case ((state, current), ref) =>
         val (state2, next) =
@@ -66,24 +67,51 @@ object DBuildRunner {
     }
   }
 
-  // verify that the requested projects in SbtBuildConfig actually exist
-  def verifySubProjects(requestedProjects: Seq[String], refs: Seq[sbt.ProjectRef], baseDirectory: File): Unit = {
+  //
+  // The methods getSortedProjects and verifySubProjects are listed here, but are also
+  // called by DependencyAnalysis.
+  //
+  // During DependencyAnalysis, we use getSortedProjects (and therefore verifySubProjects)
+  // over the requested and excluded lists, as described by the user, and those lists may
+  // contain patterns. However, when called during the build from runAggregate(), the list
+  // of projects should already be resolved: if a pattern is found, then we have an internal
+  // error of some sort.
+  //
+
+  // Verify that the requested projects in SbtBuildConfig actually exist.
+  def verifySubProjects(requestedProjects: Seq[String], refs: Seq[sbt.ProjectRef], baseDirectory: File, acceptPatterns: Boolean): Unit = {
     if (requestedProjects.nonEmpty) {
       val uniq = requestedProjects.distinct
       if (uniq.size != requestedProjects.size) {
         sys.error("Some subprojects are listed twice: " + (requestedProjects.diff(uniq)).mkString("\"", "\", \"", "\"."))
       }
       val availableProjects = normalizedProjectNames(refs, baseDirectory)
-      val notAvailable = requestedProjects.toSet -- availableProjects
+      // Can we accept patterns? If not, check that none is present
+      val (requestedNames, requestedPatterns) = requestedProjects.toSet.partition {sbt.Project.validProjectID(_).isEmpty}
+      if (requestedPatterns.nonEmpty && !acceptPatterns) {
+        sys.error("Internal error: found pattern in the list of subprojects, but there should not be any. Please report. Subprojects: " +
+          requestedProjects.mkString("\"", "\", \"", "\"."))
+      }
+      // requestedProjects may contain patterns. We only check that the strings that represent
+      // valid sbt project IDs, and are *not* patterns, are actually names of existing subprojects.
+      val notAvailable = requestedNames.toSet -- availableProjects
       if (notAvailable.nonEmpty)
         sys.error("These subprojects were not found: " + notAvailable.mkString("\"", "\", \"", "\". ") +
           " Found: " + availableProjects.mkString("\"", "\", \"", "\". "))
     } else sys.error("Internal error: subproject list is empty")
   }
 
-  def getSortedProjects(projects: Seq[String], refs: Seq[ProjectRef], baseDirectory: File): Seq[ProjectRef] = {
-    verifySubProjects(projects, refs, baseDirectory)
-    projects map { p => refs.find(ref => (p == normalizedProjectName(ref, baseDirectory))).get }
+  def getSortedProjects(projects: Seq[String], refs: Seq[ProjectRef], baseDirectory: File, acceptPatterns: Boolean): Seq[ProjectRef] = {
+    verifySubProjects(projects, refs, baseDirectory, acceptPatterns)
+    val matcher = new regex.Perl5Matcher()
+    // We want the refs that match projects *in the order specified by projects*
+    // The code below will work regardless of whether there are patterns or not in projects.
+    projects.map { p =>
+      val pattern = new org.apache.oro.text.GlobCompiler().compile(p)
+      refs.filter { ref =>
+        matcher.matches(normalizedProjectName(ref, baseDirectory), pattern)
+      }
+    }.flatten
   }
 
   def makeBuildResults(artifacts: Seq[BuildSubArtifactsOut], localRepo: File): model.BuildArtifactsOut =

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -89,7 +89,7 @@ object DBuildRunner {
       // Can we accept patterns? If not, check that none is present
       val (requestedNames, requestedPatterns) = requestedProjects.toSet.partition {sbt.Project.validProjectID(_).isEmpty}
       if (requestedPatterns.nonEmpty && !acceptPatterns) {
-        sys.error("Internal error: found pattern in the list of subprojects, but there should not be any. Please report. Subprojects: " +
+        sys.error("Internal error: while building, the subproject list contains invalid project IDs; please report. Invalid: " +
           requestedProjects.mkString("\"", "\", \"", "\"."))
       }
       // requestedProjects may contain patterns. We only check that the strings that represent
@@ -108,9 +108,13 @@ object DBuildRunner {
     // The code below will work regardless of whether there are patterns or not in projects.
     projects.map { p =>
       val pattern = new org.apache.oro.text.GlobCompiler().compile(p)
-      refs.filter { ref =>
+      val filtered = refs.filter { ref =>
         matcher.matches(normalizedProjectName(ref, baseDirectory), pattern)
       }
+      if (filtered.isEmpty) {
+        println("*** Warning: \"" + p + "\" does not match any known subproject")
+      }
+      filtered
     }.flatten
   }
 

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DependencyAnalysis.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DependencyAnalysis.scala
@@ -8,7 +8,7 @@ import com.typesafe.dbuild.model
 import com.typesafe.dbuild.plugin.StateHelpers._
 import com.typesafe.dbuild.support.sbt.ExtractionInput
 import com.typesafe.dbuild.support.NameFixer.fixName
-import DBuildRunner.{ getSortedProjects, verifySubProjects }
+import DBuildRunner.getSortedProjects
 import com.typesafe.dbuild.model.Utils.{ writeValue, readValue }
 import org.apache.commons.io.FileUtils.writeStringToFile
 
@@ -110,7 +110,7 @@ object DependencyAnalysis {
     // if anything in the passed projects list is incorrect. But don't call getSortedProjects() or verifySubProjects() if the
     // projects list is empty.
     val excluded = if (excludedProjects.nonEmpty)
-      getSortedProjects(excludedProjects, allRefs, baseDirectory)
+      getSortedProjects(excludedProjects, allRefs, baseDirectory, acceptPatterns = true)
     else
       Seq.empty
 
@@ -118,7 +118,7 @@ object DependencyAnalysis {
       if (projects.isEmpty)
         allRefs.diff(excluded)
       else {
-        val requestedPreExclusion = getSortedProjects(projects, allRefs, baseDirectory)
+        val requestedPreExclusion = getSortedProjects(projects, allRefs, baseDirectory, acceptPatterns = true)
         if (requestedPreExclusion.intersect(excluded).nonEmpty) {
           log.warn(normalizedProjectNames(requestedPreExclusion.intersect(excluded))
             mkString ("*** Warning *** You are simultaneously requesting and excluding some subprojects; they will be excluded. They are: ", ",", ""))


### PR DESCRIPTION
This pull request allows for an easier specification of groups of sbt subprojects in dbuild's configuration files, by allowing patterns in the "projects" and "exclude" clauses. It also allows for an easy inclusion or exclusion of subprojects that may or may not be present.
Fixes https://github.com/lightbend/dbuild/issues/211