### PR TITLE
 Allow an empty selection of subprojects in an sbt-based project

### DIFF
--- a/docs/src/sphinx/notifications.rst
+++ b/docs/src/sphinx/notifications.rst
@@ -137,6 +137,8 @@ matches the "when" selector. The possible outcomes are arranged in a tree, as fo
    +----- good +---- success
    |           |
    |           +---- unchanged
+   |           |
+   |           +---- empty
    |
    +------ bad +---- failed
                |
@@ -186,6 +188,15 @@ unchanged
   dbuild (project ".") is always executed, therefore its outcome cannot
   be "unchanged": if all its projects are unchanged and all the accessory tasks
   completed successfully, its final outcome will be "success".
+
+empty
+  It means that a project was not rebuilt, since no subprojects were selected.
+  That may happen if the list of subprojects contained patterns which matched
+  nothing, or if the exclusion list excludes all of the subprojects that would
+  be built according to the requested list.
+  Please remember that an empty requested list ("projects"), by itself, is
+  interpreted as "build all subprojects"; in that case, the outcome can be
+  empty only if "excludes" explicitly lists all of the available subprojects.
 
 failed
   This outcome means that dbuild reached the point in which the actual project

--- a/metadata/src/main/scala/com/typesafe/dbuild/model/BuildOutcome.scala
+++ b/metadata/src/main/scala/com/typesafe/dbuild/model/BuildOutcome.scala
@@ -52,6 +52,14 @@ case class BuildUnchanged(project: String, outcomes: Seq[BuildOutcome], artsOut:
   override def whenIDs: Seq[String] = "unchanged" +: super.whenIDs
 }
 
+/** It was not necessary to run this build, since no projects were selected. */
+case class BuildEmpty(project: String, outcomes: Seq[BuildOutcome], artsOut: BuildArtifactsOut) extends BuildGood {
+  def withOutcomes(os:Seq[BuildOutcome])=copy(outcomes=os)
+  override def toString() = "BuildEmpty(" + project + ")"
+  def status() = "SUCCESS (empty: no subprojects selected)"
+  override def whenIDs: Seq[String] = "empty" +: super.whenIDs
+}
+
 /** This build was attempted, but an error condition occurred while executing it. */
 case class BuildFailed(project: String, outcomes: Seq[BuildOutcome], cause: String) extends BuildBad {
   def withOutcomes(os:Seq[BuildOutcome])=copy(outcomes=os)

--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -98,7 +98,7 @@ object DBuildRunner {
       if (notAvailable.nonEmpty)
         sys.error("These subprojects were not found: " + notAvailable.mkString("\"", "\", \"", "\". ") +
           " Found: " + availableProjects.mkString("\"", "\", \"", "\". "))
-    } else sys.error("Internal error: subproject list is empty")
+    }
   }
 
   def getSortedProjects(projects: Seq[String], refs: Seq[ProjectRef], baseDirectory: File, acceptPatterns: Boolean): Seq[ProjectRef] = {

--- a/proj/src/main/scala/com/typesafe/dbuild/project/build/LocalBuildRunner.scala
+++ b/proj/src/main/scala/com/typesafe/dbuild/project/build/LocalBuildRunner.scala
@@ -33,8 +33,11 @@ class LocalBuildRunner(builder: BuildRunner,
       case t: RepositoryException =>
         log.debug("Failed to resolve: " + build.uuid + " from " + build.config.name)
         //log.trace(t)
-        BuildSuccess(build.config.name, children, runLocalBuild(target, build, tracker, outProjects,
-          buildData))
+        val artifactsOut = runLocalBuild(target, build, tracker, outProjects, buildData)
+        if (artifactsOut.results.isEmpty)
+          BuildEmpty(build.config.name, children, artifactsOut)
+        else
+          BuildSuccess(build.config.name, children, artifactsOut)
     }
   }
 


### PR DESCRIPTION
Also made some code behave more consistently in the process.