### PR TITLE
Don't error on scripted-plugin missing

### DIFF
--- a/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
+++ b/plugin/src/main/scala/com/typesafe/dbuild/plugin/DBuildRunner.scala
@@ -189,7 +189,9 @@ object DBuildRunner {
       if (!(modules exists { i => i.getOrganisation == m.organization && fixName(i.getName) == fixName(m.name) })) {
         // Do we have a Scala-based library dependency that was not rewritten? We can recognize it
         // since there is a cross version suffix attached to the name, hence m.name != fixName(m.name)
-        if ((m.name != fixName(m.name) || m.crossVersion != crossDisabled)) {
+        // Note: but ignore scripted (as of sbt 1 scripted is crossBinary & as of 1.2+ sbt's main depends on it)
+        if ((m.name != fixName(m.name) || m.crossVersion != crossDisabled)
+          && !(m.organization == "org.scala-sbt" && m.name.startsWith("scripted-"))) {
           // If we are here, it means that this is a library dependency that is required,
           // that refers to an artifact that is not provided by any project in this build,
           // and that needs a certain Scala version (range) in order to work as intended.


### PR DESCRIPTION
Here's what it looks like if you remove the "check-missing: false"
workaround for munit:

    [munit] --== Building munit ==--
    [munit] Resolving: https://github.com/scalameta/munit.git#ba5d46b03559b0d7c3f0f11f644bf1dd0ab5e353 in directory: ./target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55
    [munit] Fetching https://github.com/scalameta/munit.git
    [munit] into /d/scala-community-build/clones-0.9.16/566368c6358ca0f0b789b587f68d6e2e1673e2f1-munit
    [munit] Took: 00h 00m 00.5s
    [munit] Cloning /d/scala-community-build/clones-0.9.16/566368c6358ca0f0b789b587f68d6e2e1673e2f1-munit
    [munit] to /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55
    [munit] Took: 00h 00m 00.0s
    [munit] Fetching /d/scala-community-build/clones-0.9.16/566368c6358ca0f0b789b587f68d6e2e1673e2f1-munit
    [munit] into /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55
    [munit] Took: 00h 00m 00.0s
    [munit] Resolving artifacts, level 0, space: default
    [munit] Retrieved from project cloc-plugin (commit: 25781fdfc18fcfbdbbf972b18d9897dbff542e2c): 4 artifacts
    [munit] Retrieved from project scala (commit: none): 7 artifacts
    [munit] Written RepeatableProjectBuild metadata: meta/project/435473839c73b03a249a5c8cba6d51e8f3ebdb55
    [munit] Using sbt version: 1.3.8
    [munit:error] OpenJDK 64-Bit Server VM warning: Ignoring option MaxPermSize; support was removed in 8.0
    [munit] [info] Updated file /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/project/build.properties: set sbt.version to 1.3.8
    [munit] [info] Loading settings for project munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55-build-build from ÿÿÿÿÿÿÿÿÿÿ~~~~dbuild~defs.sbt ...
    [munit] [info] Loading project definition from /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/project/project
    [munit] [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
    [munit] [info] Loading settings for project munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55-build from ÿÿÿÿÿÿÿÿÿÿ~~~~dbuild~defs.sbt,plugins.sbt ...
    [munit] [info] Loading project definition from /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/project
    [munit] [info] Adding resolvers to retrieve build artifacts in one scope
    [munit] [info] Updating dependencies in one scope
    [munit] [info] Updating overrides in 2 scopes
    [munit] [info] Patching the inter-project resolver in one scope
    [munit] [info] Patching Ivy paths in 2 scopes
    [munit] [info] Disabling Scala binary checking in 2 scopes
    [munit] [info] Resetting onLoad... in one scope
    [munit] [warn] **** Missing dependency: the library org.scala-sbt#scripted-plugin is not provided (in space "") by any project in this configuration file.
    [munit] [warn] The library (and possibly some of its dependencies) will be retrieved from the external repositories.
    [munit] [warn] In order to control which version is used, you may want to add this dependency to the dbuild configuration file.
    [munit] [info] Loading project definition from /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/project
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: com.geirsson#sbt-ci-release (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: com.eed3si9n#sbt-buildinfo (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: org.scalameta#sbt-mdoc (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: org.scalameta#sbt-scalafmt (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: ch.epfl.lamp#sbt-dotty (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: ch.epfl.lamp#sbt-dotty (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: ch.epfl.scala#sbt-scalafix (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: org.portable-scala#sbt-scalajs-crossproject (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: org.portable-scala#sbt-scala-native-crossproject (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: org.scala-native#sbt-scala-native (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] This sbt plugin is not provided (in space "") by any project within this dbuild config: org.scala-js#sbt-scalajs (sbtVersion=1.0, scalaVersion=2.12)
    [munit] [warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
    [munit] [info] Compiling 8 Scala sources to /d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/project/target/scala-2.12/sbt-1.0/classes ...
    [munit] [info] Done compiling.
    [munit] [info] Loading settings for project munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55 from ÿÿÿÿÿÿÿÿÿÿ~~~~dbuild~defs.sbt,build.sbt ...
    [munit] [info] Set current project to munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55 (in build file:/d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/)
    [munit] [info] Adding resolvers to retrieve build artifacts in 10 scopes
    [munit] [info] Updating dependencies in 10 scopes
    [munit] [info] Updating overrides in 11 scopes
    [munit] [info] Preparing Scala binaries: scala-library version 2.13.2-bin-516472d
    [munit] [info] Setting Scala version to: 2.13.2-bin-516472d in 15 scopes
    [munit] [info] Setting Scala instance in 20 scopes
    [munit] [info] Patching the inter-project resolver in 10 scopes
    [munit] [info] Disabling cross version in 11 scopes
    [munit] [info] Setting Scala binary version to full in 21 scopes
    [munit] [info] Patching Ivy paths in 11 scopes
    [munit] [info] Disabling Scala binary checking in 20 scopes
    [munit] [info] Resetting publish task in 10 scopes
    [munit] [info] Updating publishTo repo in 11 scopes
    [munit] [info] Found publishMavenStyle in 11 scopes; changing publishTo settings accordingly.
    [munit] [info] Updating version strings in 2 scopes
    [munit] [info] Resetting onLoad... in one scope
    [munit] [error] **** Missing dependency: the library org.scala-sbt#scripted-plugin is not provided (in space "default") by any project in this configuration file.
    [munit] [error] In order to control which version is used, please add the corresponding project to the build file
    [munit] [error] (or use "check-missing:false" to ignore (not recommended)).
    [munit:error] java.lang.reflect.InvocationTargetException
    [munit:error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    [munit:error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    [munit:error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [munit:error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    [munit:error] 	at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaVanillaMethodMirror3.jinvokeraw(JavaMirrors.scala:427)
    [munit:error] 	at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaMethodMirror.jinvoke(JavaMirrors.scala:373)
    [munit:error] 	at scala.reflect.runtime.JavaMirrors$JavaMirror$JavaVanillaMethodMirror.apply(JavaMirrors.scala:389)
    [munit:error] 	at com.typesafe.dbuild.adapter.Adapter$.reapplySettings(Adapter.scala:86)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.newState(DBuildRunner.scala:769)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.$anonfun$rewire$4(DBuildRunner.scala:817)
    [munit:error] 	at com.typesafe.dbuild.plugin.StateHelpers$.saveLastMsg(StateHelpers.scala:40)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.$anonfun$rewire$2(DBuildRunner.scala:814)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.rewire(DBuildRunner.scala:817)
    [munit:error] 	at $d1d8ea035ae0f355c6aa$.$anonfun$$sbtdef$2(/d/scala-community-build/target-0.9.16/project-builds/munit-435473839c73b03a249a5c8cba6d51e8f3ebdb55/ÿÿÿÿÿÿÿÿÿÿ~~~~dbuild~defs.sbt:3)
    [munit:error] 	at scala.Function1.$anonfun$andThen$1(Function1.scala:57)
    [munit:error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
    [munit:error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
    [munit:error] 	at sbt.Project$.setProject(Project.scala:484)
    [munit:error] 	at sbt.BuiltinCommands$.doLoadProject(Main.scala:852)
    [munit:error] 	at sbt.BuiltinCommands$.$anonfun$loadProjectImpl$2(Main.scala:801)
    [munit:error] 	at sbt.Command$.$anonfun$applyEffect$4(Command.scala:149)
    [munit:error] 	at sbt.Command$.$anonfun$applyEffect$2(Command.scala:144)
    [munit:error] 	at sbt.Command$.process(Command.scala:187)
    [munit:error] 	at sbt.MainLoop$.process$1(MainLoop.scala:193)
    [munit:error] 	at sbt.MainLoop$.processCommand(MainLoop.scala:229)
    [munit:error] 	at sbt.MainLoop$.$anonfun$next$2(MainLoop.scala:142)
    [munit:error] 	at sbt.State$StateOpsImpl$.runCmd$1(State.scala:273)
    [munit:error] 	at sbt.State$StateOpsImpl$.process$extension(State.scala:277)
    [munit:error] 	at sbt.MainLoop$.$anonfun$next$1(MainLoop.scala:142)
    [munit:error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
    [munit:error] 	at sbt.MainLoop$.next(MainLoop.scala:142)
    [munit:error] 	at sbt.MainLoop$.run(MainLoop.scala:133)
    [munit:error] 	at sbt.MainLoop$.$anonfun$runWithNewLog$1(MainLoop.scala:111)
    [munit:error] 	at sbt.io.Using.apply(Using.scala:27)
    [munit:error] 	at sbt.MainLoop$.runWithNewLog(MainLoop.scala:105)
    [munit:error] 	at sbt.MainLoop$.runAndClearLast(MainLoop.scala:60)
    [munit:error] 	at sbt.MainLoop$.runLoggedLoop(MainLoop.scala:45)
    [munit:error] 	at sbt.MainLoop$.runLogged(MainLoop.scala:36)
    [munit:error] 	at sbt.StandardMain$.runManaged(Main.scala:132)
    [munit:error] 	at sbt.xMain$.run(Main.scala:67)
    [munit:error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    [munit:error] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    [munit:error] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [munit:error] 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
    [munit:error] 	at sbt.internal.XMainConfiguration.run(XMainConfiguration.scala:45)
    [munit:error] 	at sbt.xMain.run(Main.scala:39)
    [munit:error] 	at xsbt.boot.Launch$$anonfun$run$1.apply(Launch.scala:109)
    [munit:error] 	at xsbt.boot.Launch$.withContextLoader(Launch.scala:128)
    [munit:error] 	at xsbt.boot.Launch$.run(Launch.scala:109)
    [munit:error] 	at xsbt.boot.Launch$$anonfun$apply$1.apply(Launch.scala:35)
    [munit:error] 	at xsbt.boot.Launch$.launch(Launch.scala:117)
    [munit:error] 	at xsbt.boot.Launch$.apply(Launch.scala:18)
    [munit:error] 	at xsbt.boot.Boot$.runImpl(Boot.scala:41)
    [munit:error] 	at xsbt.boot.Boot$.main(Boot.scala:17)
    [munit:error] 	at xsbt.boot.Boot.main(Boot.scala)
    [munit:error] Caused by: java.lang.RuntimeException: Required dependency not found
    [munit:error] 	at scala.sys.package$.error(package.scala:30)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.$anonfun$fixModule$8(DBuildRunner.scala:205)
    [munit:error] 	at scala.Option.getOrElse(Option.scala:189)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.fixModule(DBuildRunner.scala:180)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.$anonfun$fixOverrides2$4(DBuildRunner.scala:393)
    [munit:error] 	at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:238)
    [munit:error] 	at scala.collection.Iterator.foreach(Iterator.scala:941)
    [munit:error] 	at scala.collection.Iterator.foreach$(Iterator.scala:941)
    [munit:error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
    [munit:error] 	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
    [munit:error] 	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
    [munit:error] 	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
    [munit:error] 	at scala.collection.TraversableLike.map(TraversableLike.scala:238)
    [munit:error] 	at scala.collection.TraversableLike.map$(TraversableLike.scala:231)
    [munit:error] 	at scala.collection.AbstractTraversable.map(Traversable.scala:108)
    [munit:error] 	at com.typesafe.dbuild.plugin.DBuildRunner$.$anonfun$fixOverrides2$3(DBuildRunner.scala:393)
    [munit:error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:49)
    [munit:error] 	at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:223)
    [munit:error] 	at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:166)
    [munit:error] 	at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:87)
    [munit:error] 	at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:99)
    [munit:error] 	at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:94)
    [munit:error] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    [munit:error] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    [munit:error] 	at java.base/java.lang.Thread.run(Thread.java:834)
    [munit] [error] Required dependency not found
    [munit] [error] Use 'last' for the full log.
    [munit] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
    [munit:error] java.lang.RuntimeException:
    [munit:error] 	at scala.sys.package$.error(package.scala:27)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtRunner.com$typesafe$dbuild$support$sbt$SbtRunner$$processCommand(SbtRunner.scala:94)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtRunner$$anonfun$run$1$$anonfun$apply$2$$anonfun$apply$3.apply(SbtRunner.scala:75)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtRunner$$anonfun$run$1$$anonfun$apply$2$$anonfun$apply$3.apply(SbtRunner.scala:75)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtRunner$$anonfun$run$1.apply(SbtRunner.scala:75)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtRunner$$anonfun$run$1.apply(SbtRunner.scala:66)
    [munit:error] 	at sbt.IO$.withTemporaryFile(IO.scala:389)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtRunner.run(SbtRunner.scala:66)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtBuilder$.buildSbtProject(SbtBuildRunner.scala:93)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtBuildSystem.runBuild(SbtBuildSystem.scala:96)
    [munit:error] 	at com.typesafe.dbuild.support.sbt.SbtBuildSystem.runBuild(SbtBuildSystem.scala:22)
    [munit] --== End Building munit ==--

@cunei if you have any other suggestions, I'm happy to try other things.

Also, I haven't tested this, but from my understanding it should work.